### PR TITLE
Initial Setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: "2.6.0"
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+AllCops:
+  SuggestExtensions: false
+
+Metrics/BlockLength:
+  IgnoredMethods: ["describe", "context"]
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+
+gem 'distribution'
+gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.4.4)
+    distribution (0.8.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+
+PLATFORMS
+  x86_64-darwin-19
+
+DEPENDENCIES
+  distribution
+  rspec
+
+BUNDLED WITH
+   2.2.26

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # Summary
 
-`option_calculations` is a module designed to aid with the pricing of put and call options contracts.
+`option_calculations` is a module designed to aid with the pricing of put and call options contracts. Once all of the methods have been added it will be turned into a gem.
 
 # Use
+
+require 'option_calculations'
+
+```
+call = OptionCalculations::Call.new(underlying_stock_price: 324, option_strike_price: 124.50, risk_free_rate_of_return: 0.03, underlying_standard_deviation: 0.2, years_until_maturity: 3)
+
+```
+
+The following methods currently exist for call options:
+
+- `price`
+- `delta`
+
+# To dos
+
+- Error handling
+- Add put option contracts
+- Add additional Greek Calculations
 
 # Additional reading
 

--- a/lib/option_calculations.rb
+++ b/lib/option_calculations.rb
@@ -1,0 +1,1 @@
+require_relative 'option_calculations/call'

--- a/lib/option_calculations/base.rb
+++ b/lib/option_calculations/base.rb
@@ -1,0 +1,53 @@
+require 'distribution'
+
+module OptionCalculations
+  #   performs base calculations for both put and call options
+  class Base
+    attr_accessor :underlying_stock_price,
+                  :option_strike_price,
+                  :risk_free_rate_of_return,
+                  :underlying_standard_deviation,
+                  :years_until_maturity
+
+    def initialize(attributes)
+      @underlying_stock_price = attributes.fetch(:underlying_stock_price, 0)
+      @option_strike_price = attributes.fetch(:option_strike_price, 0)
+      @risk_free_rate_of_return = attributes.fetch(:risk_free_rate_of_return, 0)
+      @underlying_standard_deviation = attributes.fetch(:underlying_standard_deviation, 0)
+      @years_until_maturity = attributes.fetch(:years_until_maturity, 0)
+    end
+
+    private
+
+    # rubocop:disable Metrics/MethodLength
+    def d1
+      (
+        get_natural_log(underlying_stock_price / option_strike_price.to_f) +
+                  (
+                    (
+                      risk_free_rate_of_return +
+                        (
+                          (underlying_standard_deviation**2) * 0.5
+                        )
+                    ) * years_until_maturity
+                  )
+      ) / (
+        underlying_standard_deviation * Math.sqrt(years_until_maturity).to_f
+      )
+    end
+
+    # rubocop:enable Metrics/MethodLength
+
+    def d2
+      d1 - underlying_standard_deviation * Math.sqrt(years_until_maturity)
+    end
+
+    def get_natural_log(value)
+      Math.log(value, e)
+    end
+
+    def e
+      Math.exp(1)
+    end
+  end
+end

--- a/lib/option_calculations/call.rb
+++ b/lib/option_calculations/call.rb
@@ -1,0 +1,16 @@
+require 'distribution'
+require_relative 'base'
+
+module OptionCalculations
+  # calculates various metrics associated with call options
+  class Call < Base
+    def price
+      (delta * underlying_stock_price) -
+        (Distribution::Normal.cdf(d2) * option_strike_price * e**(-risk_free_rate_of_return * years_until_maturity))
+    end
+
+    def delta
+      Distribution::Normal.cdf(d1)
+    end
+  end
+end

--- a/spec/option_calculations/base_spec.rb
+++ b/spec/option_calculations/base_spec.rb
@@ -1,0 +1,78 @@
+require 'option_calculations'
+
+RSpec.describe OptionCalculations::Base do
+  context 'when a call option with all properties is initialized' do
+    let(:base_option) do
+      described_class.new(
+        underlying_stock_price: 100,
+        option_strike_price: 125,
+        risk_free_rate_of_return: 0.03,
+        underlying_standard_deviation: 0.2,
+        years_until_maturity: 3
+      )
+    end
+
+    it 'returns the provided value for "underlying_stock_price"' do
+      expect(base_option.underlying_stock_price).to eq(100)
+    end
+
+    it 'returns the provided value for "option_strike_price"' do
+      expect(base_option.option_strike_price).to eq(125)
+    end
+
+    it 'returns the provided value for "risk_free_rate_of_return"' do
+      expect(base_option.risk_free_rate_of_return).to eq(0.03)
+    end
+
+    it 'returns the provided value for "underlying_standard_deviation"' do
+      expect(base_option.underlying_standard_deviation).to eq(0.2)
+    end
+
+    it 'returns the provided value for "years_until_maturity"' do
+      expect(base_option.years_until_maturity).to eq(3)
+    end
+
+    it 'calculates "#d1"' do
+      expect(base_option.send(:d1)).to eq(-0.21114724520372083)
+    end
+
+    it 'calculates "#d2"' do
+      expect(base_option.send(:d2)).to eq(-0.5575574067174963)
+    end
+
+    it 'calculates "#e"' do
+      expect(base_option.send(:e)).to eq(2.718281828459045)
+    end
+
+    it 'calculates "#get_natural_log"' do
+      expect(base_option.send(:get_natural_log, 2)).to eq(0.6931471805599453)
+    end
+  end
+  context 'when an option with only some properties are set' do
+    let(:base_option) do
+      described_class.new(
+        underlying_stock_price: 132
+      )
+    end
+
+    it 'sets the provided property as what is provided' do
+      expect(base_option.underlying_stock_price).to eq(132)
+    end
+
+    it 'sets "option_strike_price" to zero' do
+      expect(base_option.option_strike_price).to eq(0)
+    end
+
+    it 'sets "risk_free_rate_of_return" to zero' do
+      expect(base_option.risk_free_rate_of_return).to eq(0)
+    end
+
+    it 'sets "underlying_standard_deviation" to zero' do
+      expect(base_option.underlying_standard_deviation).to eq(0)
+    end
+
+    it 'sets "years_until_maturity" to zero' do
+      expect(base_option.years_until_maturity).to eq(0)
+    end
+  end
+end

--- a/spec/option_calculations/call_spec.rb
+++ b/spec/option_calculations/call_spec.rb
@@ -1,0 +1,80 @@
+require 'option_calculations'
+
+RSpec.describe OptionCalculations::Call do
+  context 'when a call option with all properties is initialized' do
+    let(:call_option) do
+      described_class.new(
+        underlying_stock_price: 100,
+        option_strike_price: 125,
+        risk_free_rate_of_return: 0.03,
+        underlying_standard_deviation: 0.2,
+        years_until_maturity: 3
+      )
+    end
+
+    it 'returns the provided value for "underlying_stock_price"' do
+      expect(call_option.underlying_stock_price).to eq(100)
+    end
+
+    it 'returns the provided value for "option_strike_price"' do
+      expect(call_option.option_strike_price).to eq(125)
+    end
+
+    it 'returns the provided value for "risk_free_rate_of_return"' do
+      expect(call_option.risk_free_rate_of_return).to eq(0.03)
+    end
+
+    it 'returns the provided value for "underlying_standard_deviation"' do
+      expect(call_option.underlying_standard_deviation).to eq(0.2)
+    end
+
+    it 'returns the provided value for "years_until_maturity"' do
+      expect(call_option.years_until_maturity).to eq(3)
+    end
+
+    it "can calculate the call's '#price'" do
+      expect(call_option.price).to eq(8.671598717749958)
+    end
+
+    it "can calculate the call's '#delta'" do
+      expect(call_option.delta).to eq(0.4163861874197372)
+    end
+  end
+
+  context 'when time_until_maturity is 0' do
+    let(:time_until_maturity) { 0 }
+    let(:call_option) do
+      described_class.new(
+        underlying_stock_price: 100,
+        option_strike_price: strike_price,
+        risk_free_rate_of_return: 0.03,
+        underlying_standard_deviation: 0.2,
+        years_until_maturity: time_until_maturity
+      )
+    end
+
+    context 'when an in the money call is added' do
+      let(:strike_price) { 75 }
+
+      it 'returns the correct "#price"' do
+        expect(call_option.price).to eq(25.0)
+      end
+
+      it 'returns the correct "#delta"' do
+        expect(call_option.delta).to eq(1)
+      end
+    end
+
+    context 'when an out of the money call is added' do
+      let(:strike_price) { 125 }
+
+      it 'returns the correct "#price"' do
+        expect(call_option.price).to eq(0)
+      end
+
+      it 'returns the correct "#delta"' do
+        expect(call_option.delta).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the initial setup for option calcs, including the base calculations & the `price` and `delta` calculations for call contracts. 

Next, I will add put contracts, followed by some of the additional greek calculations. 